### PR TITLE
Externe aufbewahrung der Daten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+confidentials.h

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Einfache Echtzeit-Anzeige der YouTube-Abonnentenzahl unter Verwendung eines ESP8
 
 ## Inhaltsverzeichniss <!-- omit in toc -->
 
-- [Vorraussetzungen](#vorraussetzungen)
+- [Vorraussetzungen](#vorraussetzungen) 
 - [Materialien](#materialien)
 - [Bibliotheken](#bibliotheken)
 - [Boardkonfiguration](#boardkonfiguration)
@@ -31,12 +31,14 @@ Einfache Echtzeit-Anzeige der YouTube-Abonnentenzahl unter Verwendung eines ESP8
 ## Bibliotheken
 
 - [YouTubeApi](https://github.com/witnessmenow/arduino-youtube-api) - *getestet mit v. 2.0.0*
-- [ArduinoJson](https://github.com/bblanchon/ArduinoJson) - *getestet mit v. 6.15.2*
+- [ArduinoJson](https://github.com/bblanchon/ArduinoJson) - *getestet mit v. 6.17.2*
 - [LedControl](https://github.com/wayoda/LedControl) - *getestet mit v. 1.0.6*
 
 Installiere die Bibliotheken einfach über den [Bibliotheksverwalter](https://www.arduino.cc/en/Guide/Libraries#toc3) unter **Werkzeuge ➔ Bibliotheken verwalten...** oder [manuell](https://www.arduino.cc/en/Guide/Libraries#toc4) per `.zip` von GitHub.
 
 ## Boardkonfiguration
+
+Um deinen Arduino mit dem Internet zu verbinden, benenne `confidentials_example.h` in `confidentials.h` um und ändere in der Datei die angegebenen variablen.
 
 Bevor du dich in dieses Projekt stürzt, solltest du dich zunächst vergewissern, dass deine Arduino-Software richtig eingerichtet ist, um das von dir verwendete Board zu programmieren.
 

--- a/YouTube-subcounter/YouTube-subcounter.ino
+++ b/YouTube-subcounter/YouTube-subcounter.ino
@@ -2,13 +2,15 @@
  * YouTube Subscriber counter
  * by stealthyV1per
  * 
- * Displays your current subscriber count 
+ * Displays your current subscriber count in real time
  * 
  * Based on: https://www.instructables.com/id/YouTube-Subscriber-Counter-With-ESP8266-V2/
  **/
 #include <ESP8266WiFi.h>
 #include <WiFiClientSecure.h>
 #include <Wire.h>
+
+#include "confidentials.h"
 
 /**
  * Additional Libraries - each one of these will need to be installed.
@@ -24,17 +26,6 @@
 #include <LedControl.h>
 // Library used for simple segmented display
 // https://github.com/wayoda/LedControl
-
-/**
- * Replace the following!
- **/
-// WiFi Network settings
-#define WIFI_SSID ""
-#define WIFI_PASSWORD ""
-
-// Google API key and YouTube channel ID
-#define API_KEY "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-#define CHANNEL_ID "YOUR CHANNEL ID HERE"
 
 /**
  * Replace if needed

--- a/YouTube-subcounter/confidentials_example.h
+++ b/YouTube-subcounter/confidentials_example.h
@@ -1,0 +1,15 @@
+#ifndef CONFIDENTIALS_H
+#define CONFIDENTIALS_H
+
+/**
+ * Replace the following!
+ **/
+// WiFi Network settings
+#define WIFI_SSID "Mein Wifi Netzwerk"
+#define WIFI_PASSWORD "p@$$w0rd"
+
+// Google API key and YouTube channel ID
+#define API_KEY "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+#define CHANNEL_ID "YYYYYYYYYYYYYYYYYYYYYYYY"
+
+#endif


### PR DESCRIPTION
Die Zugangsdaten für das Wi-Fi Netzwerk und die Kanal-ID (inkl. API Key) werden in einer separaten Datei aufbewahrt.

Dies verhindert, dass ein Entwickler wichtige Informationen versehentlich preisgibt.